### PR TITLE
DEV: Refactor post-stream error handling for unlock plugin

### DIFF
--- a/.discourse-compatibility
+++ b/.discourse-compatibility
@@ -1,3 +1,4 @@
+< 3.5.0.beta8-dev: b4f01179470257fbf1ae079ff986c8979bf695d6
 < 3.5.0.beta5-dev: e58bf4f1667e9ed4e3acead86da3cacaa65be89f
 < 3.5.0.beta3-dev: 2621ba71bc71f225706bb55b2d5ea448f5dc8d26
 < 3.5.0.beta1-dev: 525fd80dc5eb246c8a436d72771a82b73e0546be

--- a/assets/javascripts/discourse/initializers/extend-for-unlock.js
+++ b/assets/javascripts/discourse/initializers/extend-for-unlock.js
@@ -19,11 +19,12 @@ export default {
   name: "apply-unlock",
 
   initialize() {
-    withPluginApi("0.11.2", (api) => {
-      api.modifyClass("model:post-stream", {
-        errorLoading(result) {
-          const { status } = result.jqXHR;
-          const { lock, url } = result.jqXHR.responseJSON;
+    withPluginApi((api) => {
+      api.registerBehaviorTransformer(
+        "post-stream-error-loading",
+        ({ context: { error }, next: _super }) => {
+          const { status } = error.jqXHR;
+          const { lock, url } = error.jqXHR.responseJSON;
 
           if (status === 402 && lock) {
             if (getOwner(this).lookup("service:current-user")) {
@@ -37,10 +38,10 @@ export default {
                 .replaceWith("login");
             }
           } else {
-            return this._super(result);
+            return _super(error);
           }
-        },
-      });
+        }
+      );
 
       reset();
 


### PR DESCRIPTION
This PR refactors error handling in the unlock plugin by replacing `modifyClass` with `registerBehaviorTransformer`. This change ensures better compliance with the plugin API and improves integration with custom behaviors.

Requires https://github.com/discourse/discourse/pull/33396.